### PR TITLE
 Now use tfjs-node-gpu, add testing files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 node_modules
 .VSCodeCounter
+assets/google
 assets/data-set
 assets/LBF Database.json
 assets/LBF Database.json.gz
+build/
+testing/*notes.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 node_modules
 .VSCodeCounter
-assets/google
+/assets/google/*
 assets/data-set
 assets/LBF Database.json
 assets/LBF Database.json.gz

--- a/assets/google/oauth2-config.json
+++ b/assets/google/oauth2-config.json
@@ -1,0 +1,5 @@
+{
+	"clientId": "",
+	"secret": "",
+	"redirect": "https://localhost"
+}

--- a/face-rec.js
+++ b/face-rec.js
@@ -1,6 +1,6 @@
 // import nodejs bindings to native tensorflow,
 // not required, but will speed up things drastically (python required)
-const tf = require('@tensorflow/tfjs-node');
+const tf = require('@tensorflow/tfjs-node-gpu');
 // implements nodejs wrappers for HTMLCanvasElement, HTMLImageElement, ImageData
 const canvas = require('canvas');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "facial-rec-photo-gallery",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -67,25 +67,25 @@
       }
     },
     "@tensorflow/tfjs": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-1.5.1.tgz",
-      "integrity": "sha512-WiE+JQ3ibr5LibGiBz6HWUqLJW8HiX6ywUSCA7ehZ67vFsw4mPuVjv0WEEUfD/l47PkXYVAmWd+RYOJiuZC7Eg==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-1.5.2.tgz",
+      "integrity": "sha512-BCvcbnkE/zMdORIGE7TFAiJU3zLLVUaRv/HyWucVVyHU40oU4L5mGyRXK6RwqU38KmeK3HSI5rUHop4cLNUaRQ==",
       "requires": {
-        "@tensorflow/tfjs-converter": "1.5.1",
-        "@tensorflow/tfjs-core": "1.5.1",
-        "@tensorflow/tfjs-data": "1.5.1",
-        "@tensorflow/tfjs-layers": "1.5.1"
+        "@tensorflow/tfjs-converter": "1.5.2",
+        "@tensorflow/tfjs-core": "1.5.2",
+        "@tensorflow/tfjs-data": "1.5.2",
+        "@tensorflow/tfjs-layers": "1.5.2"
       }
     },
     "@tensorflow/tfjs-converter": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-1.5.1.tgz",
-      "integrity": "sha512-M9tl2/ep8ntcZpmncHwKuvThsS7TaUWqJ9vJSgJmkazwTfAvlAJmZ8/p1miJ+m5sH1EJO4oTjiEmch6g8IA5IQ=="
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-1.5.2.tgz",
+      "integrity": "sha512-RRrB8lZFxjLPHO6TwEJPgViVuJP5yqq0IPqA35PhWLYjsNNuC6Tx8vxEa5BZ0Le0mX21CTURak6pdmyac/Jc2w=="
     },
     "@tensorflow/tfjs-core": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-1.5.1.tgz",
-      "integrity": "sha512-N4fsi8mLsRwRs8UJN2cARB1rYFxyVXkLyZ4wOusiR976BwwZbCwQrTTSIPzPqYT3rwiexEUzm7sM6ZaDl5dpXA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-1.5.2.tgz",
+      "integrity": "sha512-Rj6l8xf0PxrEKctvX3bvxjqhHLaCBQT0ChvqFK6//HBu8A1/ao4SzeVKpXKNnP9Niax+qV3c9U9VcOwwIkCMag==",
       "requires": {
         "@types/offscreencanvas": "~2019.3.0",
         "@types/seedrandom": "2.4.27",
@@ -93,42 +93,28 @@
         "@types/webgl2": "0.0.4",
         "node-fetch": "~2.1.2",
         "seedrandom": "2.4.3"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
-          "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
-        }
       }
     },
     "@tensorflow/tfjs-data": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-1.5.1.tgz",
-      "integrity": "sha512-eu4X0tHS1Tng+cvMO9gkMhUWX/UZQ//VpiaZfQJfa3zvUgxw6s1MHJFb0JC1T1FOnEgDVriZ8G758ysJZOybog==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-1.5.2.tgz",
+      "integrity": "sha512-ruCsTSyH67CADWthgLQlWKh8u8YGEXD+4vsW8uOGdFNcDFLcL0ffy4jsSzIV/X6NdPIWYsvSHmiz57LtgfCFew==",
       "requires": {
         "@types/node-fetch": "^2.1.2",
         "node-fetch": "~2.1.2"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
-          "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
-        }
       }
     },
     "@tensorflow/tfjs-layers": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-1.5.1.tgz",
-      "integrity": "sha512-DyuhifqflK+bdpBRLAj3RuWm1eTVe8yNX2+WH+W+wmhpjGg7Yagnar6/66JdS2h3WUFoiplCpZRAVMVw631E5g=="
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-1.5.2.tgz",
+      "integrity": "sha512-fn2hi5D1sOKGEgiBCuoU/hTHO87znODweGivIn6x2HMtF1EC39QWroYQBWzJyrWWMOUZZ4nOFR6coA0Fkhc+nA=="
     },
     "@tensorflow/tfjs-node": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-node/-/tfjs-node-1.5.1.tgz",
-      "integrity": "sha512-gtIVn5zTLSgHlJUThN3knzKjycXOezmgL0W5MtxunJPznGmUZQive9efuCsgKcs5YKizTG+KprTILTSbi/2Owg==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-node/-/tfjs-node-1.5.2.tgz",
+      "integrity": "sha512-qihOkKbCLTDcqe3TTDbA9v00PacMzPwhspV8MEHWpohVb7itqQ8cMSE8w38b2oA+FE38c1RI7KOd2qAl5bCNHA==",
       "requires": {
-        "@tensorflow/tfjs": "1.5.1",
+        "@tensorflow/tfjs": "1.5.2",
         "adm-zip": "^0.4.11",
         "google-protobuf": "^3.9.2",
         "https-proxy-agent": "^2.2.1",
@@ -136,6 +122,66 @@
         "progress": "^2.0.0",
         "rimraf": "^2.6.2",
         "tar": "^4.4.6"
+      }
+    },
+    "@tensorflow/tfjs-node-gpu": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-node-gpu/-/tfjs-node-gpu-1.5.2.tgz",
+      "integrity": "sha512-9SLDMlOyfa0a61AdZNqpA8vCHavuHJwNx8MHwjqtEKviUGAmZEwZtkxKw9ri/xyfRo8K2weZjfhWWhzrKj1LuA==",
+      "requires": {
+        "@tensorflow/tfjs": "1.5.2",
+        "adm-zip": "^0.4.11",
+        "google-protobuf": "^3.9.2",
+        "https-proxy-agent": "^2.2.1",
+        "node-pre-gyp": "0.14.0",
+        "progress": "^2.0.0",
+        "rimraf": "^2.6.2",
+        "tar": "^4.4.6"
+      },
+      "dependencies": {
+        "@tensorflow/tfjs": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-1.5.2.tgz",
+          "integrity": "sha512-BCvcbnkE/zMdORIGE7TFAiJU3zLLVUaRv/HyWucVVyHU40oU4L5mGyRXK6RwqU38KmeK3HSI5rUHop4cLNUaRQ==",
+          "requires": {
+            "@tensorflow/tfjs-converter": "1.5.2",
+            "@tensorflow/tfjs-core": "1.5.2",
+            "@tensorflow/tfjs-data": "1.5.2",
+            "@tensorflow/tfjs-layers": "1.5.2"
+          }
+        },
+        "@tensorflow/tfjs-converter": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-1.5.2.tgz",
+          "integrity": "sha512-RRrB8lZFxjLPHO6TwEJPgViVuJP5yqq0IPqA35PhWLYjsNNuC6Tx8vxEa5BZ0Le0mX21CTURak6pdmyac/Jc2w=="
+        },
+        "@tensorflow/tfjs-core": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-core/-/tfjs-core-1.5.2.tgz",
+          "integrity": "sha512-Rj6l8xf0PxrEKctvX3bvxjqhHLaCBQT0ChvqFK6//HBu8A1/ao4SzeVKpXKNnP9Niax+qV3c9U9VcOwwIkCMag==",
+          "requires": {
+            "@types/offscreencanvas": "~2019.3.0",
+            "@types/seedrandom": "2.4.27",
+            "@types/webgl-ext": "0.0.30",
+            "@types/webgl2": "0.0.4",
+            "node-fetch": "~2.1.2",
+            "seedrandom": "2.4.3"
+          }
+        },
+        "@tensorflow/tfjs-data": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-1.5.2.tgz",
+          "integrity": "sha512-ruCsTSyH67CADWthgLQlWKh8u8YGEXD+4vsW8uOGdFNcDFLcL0ffy4jsSzIV/X6NdPIWYsvSHmiz57LtgfCFew==",
+          "requires": {
+            "@types/node-fetch": "^2.1.2",
+            "node-fetch": "~2.1.2"
+          }
+        },
+        "@tensorflow/tfjs-layers": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-1.5.2.tgz",
+          "integrity": "sha512-fn2hi5D1sOKGEgiBCuoU/hTHO87znODweGivIn6x2HMtF1EC39QWroYQBWzJyrWWMOUZZ4nOFR6coA0Fkhc+nA=="
+        }
       }
     },
     "@types/node": {
@@ -184,6 +230,15 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
     },
     "acorn": {
       "version": "7.1.0",
@@ -276,6 +331,12 @@
         }
       }
     },
+    "arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "dev": true
+    },
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -319,6 +380,12 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+      "dev": true
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -341,6 +408,12 @@
         "through2": "^3.0.1"
       }
     },
+    "bignumber.js": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
+      "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==",
+      "dev": true
+    },
     "boolean": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.0.0.tgz",
@@ -356,6 +429,12 @@
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
+      "dev": true
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -769,6 +848,15 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "electron": {
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/electron/-/electron-7.1.7.tgz",
@@ -1037,6 +1125,12 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -1136,6 +1230,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "fast-text-encoding": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.0.tgz",
+      "integrity": "sha512-R9bHCvweUxxwkDwhjav5vxpFvdPGlVngtqmx4pIZfSUhM/Q4NiIUHB456BAf+Q1Nwu3HEZYONtu+Rya+af4jiQ==",
       "dev": true
     },
     "fd-slicer": {
@@ -1281,6 +1381,62 @@
         "wide-align": "^1.1.0"
       }
     },
+    "gaxios": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-2.3.0.tgz",
+      "integrity": "sha512-VgC4JKJQAAAGK5rFZbPcS5mXsdIYVMIUJOxMjSOkYdfhB74R0L6y8PFQDdS0r1ObG6hdP11e71EjHh3xbI+6fQ==",
+      "dev": true,
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^4.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.3.0"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
+          "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
+          "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
+          "dev": true,
+          "requires": {
+            "agent-base": "5",
+            "debug": "4"
+          }
+        },
+        "node-fetch": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+          "dev": true
+        }
+      }
+    },
+    "gcp-metadata": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-3.3.1.tgz",
+      "integrity": "sha512-RrASg1HaVAxoB9Q/8sYfJ++v9PMiiqIgOrOxZeagMgS4osZtICT1lKBx2uvzYgwetxj8i6K99Z0iuKMg7WraTg==",
+      "dev": true,
+      "requires": {
+        "gaxios": "^2.1.0",
+        "json-bigint": "^0.3.0"
+      }
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -1384,10 +1540,67 @@
         "define-properties": "^1.1.3"
       }
     },
+    "google-auth-library": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-5.9.2.tgz",
+      "integrity": "sha512-rBE1YTOZ3/Hu6Mojkr+UUmbdc/F28hyMGYEGxjyfVA9ZFmq12oqS3AeftX4h9XpdVIcxPooSo8hECYGT6B9XqQ==",
+      "dev": true,
+      "requires": {
+        "arrify": "^2.0.0",
+        "base64-js": "^1.3.0",
+        "fast-text-encoding": "^1.0.0",
+        "gaxios": "^2.1.0",
+        "gcp-metadata": "^3.3.0",
+        "gtoken": "^4.1.0",
+        "jws": "^4.0.0",
+        "lru-cache": "^5.0.0"
+      }
+    },
+    "google-p12-pem": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-2.0.4.tgz",
+      "integrity": "sha512-S4blHBQWZRnEW44OcR7TL9WR+QCqByRvhNDZ/uuQfpxywfupikf/miba8js1jZi6ZOGv5slgSuoshCWh6EMDzg==",
+      "dev": true,
+      "requires": {
+        "node-forge": "^0.9.0"
+      }
+    },
     "google-protobuf": {
       "version": "3.11.2",
       "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.11.2.tgz",
       "integrity": "sha512-T4fin7lcYLUPj2ChUZ4DvfuuHtg3xi1621qeRZt2J7SvOQusOzq+sDT4vbotWTCjUXJoR36CA016LlhtPy80uQ=="
+    },
+    "googleapis": {
+      "version": "47.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-47.0.0.tgz",
+      "integrity": "sha512-+Fnjgcc3Na/rk57dwxqW1V0HJXJFjnt3aqFlckULqAqsPkmex/AyJJe6MSlXHC37ZmlXEb9ZtPGUp5ZzRDXpHg==",
+      "dev": true,
+      "requires": {
+        "google-auth-library": "^5.6.1",
+        "googleapis-common": "^3.2.0"
+      }
+    },
+    "googleapis-common": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-3.2.1.tgz",
+      "integrity": "sha512-lPAJXYpZLvY4AZp57RWj1eUXS2D5LxS3y6W0n9Jbl6eKOWmyLgz99f84XVCxVnyq8DcgV/ZAxt1lpFEzGZkVvQ==",
+      "dev": true,
+      "requires": {
+        "extend": "^3.0.2",
+        "gaxios": "^2.0.1",
+        "google-auth-library": "^5.6.1",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.9.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz",
+          "integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA==",
+          "dev": true
+        }
+      }
     },
     "got": {
       "version": "9.6.0",
@@ -1430,6 +1643,18 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
       "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
       "dev": true
+    },
+    "gtoken": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-4.1.4.tgz",
+      "integrity": "sha512-VxirzD0SWoFUo5p8RDP8Jt2AGyOmyYcT/pOUgDKJCK+iSw0TMqwrVfY37RXTNmoKwrzmDHSk0GMT9FsgVmnVSA==",
+      "dev": true,
+      "requires": {
+        "gaxios": "^2.1.0",
+        "google-p12-pem": "^2.0.0",
+        "jws": "^4.0.0",
+        "mime": "^2.2.0"
+      }
     },
     "har-schema": {
       "version": "2.0.0",
@@ -1693,6 +1918,12 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
+    "is-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+      "dev": true
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -1737,6 +1968,15 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true
+    },
+    "json-bigint": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-0.3.0.tgz",
+      "integrity": "sha1-DM2RLEuCcNBfBW+9E4FLU9OCWx4=",
+      "dev": true,
+      "requires": {
+        "bignumber.js": "^7.0.0"
+      }
     },
     "json-buffer": {
       "version": "3.0.0",
@@ -1799,6 +2039,27 @@
         "verror": "1.10.0"
       }
     },
+    "jwa": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "dev": true,
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "dev": true,
+      "requires": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "keyv": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
@@ -1855,6 +2116,15 @@
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true
     },
+    "lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "requires": {
+        "yallist": "^3.0.2"
+      }
+    },
     "matcher": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-2.1.0.tgz",
@@ -1864,6 +2134,12 @@
       "requires": {
         "escape-string-regexp": "^2.0.0"
       }
+    },
+    "mime": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+      "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+      "dev": true
     },
     "mime-db": {
       "version": "1.42.0",
@@ -1975,6 +2251,17 @@
       "requires": {
         "semver": "^5.4.1"
       }
+    },
+    "node-fetch": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+      "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
+    },
+    "node-forge": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.1.tgz",
+      "integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ==",
+      "dev": true
     },
     "node-gyp": {
       "version": "6.0.1",
@@ -2343,6 +2630,12 @@
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
       }
+    },
+    "readline": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/readline/-/readline-1.3.0.tgz",
+      "integrity": "sha1-xYDXfvLPyHUrEySYBg3JeTp6wBw=",
+      "dev": true
     },
     "regexpp": {
       "version": "2.0.1",
@@ -2870,6 +3163,12 @@
       "requires": {
         "prepend-http": "^2.0.0"
       }
+    },
+    "url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE=",
+      "dev": true
     },
     "utf8-byte-length": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -14,10 +14,13 @@
 	"devDependencies": {
 		"electron": "^7.1.7",
 		"electron-rebuild": "^1.8.8",
-		"eslint": "^6.8.0"
+		"eslint": "^6.8.0",
+		"googleapis": "^47.0.0",
+		"readline": "^1.3.0"
 	},
 	"dependencies": {
-		"@tensorflow/tfjs-node": "^1.5.1",
+		"@tensorflow/tfjs-node": "^1.5.2",
+		"@tensorflow/tfjs-node-gpu": "^1.5.2",
 		"big-json": "^3.1.0",
 		"canvas": "^2.6.1",
 		"face-api.js": "^0.22.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "facial-rec-photo-gallery",
-	"version": "2.3.0",
+	"version": "2.3.1",
 	"description": "",
 	"main": "main.js",
 	"scripts": {

--- a/testing/compression-testing.js
+++ b/testing/compression-testing.js
@@ -1,0 +1,81 @@
+const fs = require('fs');
+const path = require('path');
+const zlib = require('zlib');
+const util = require('util');
+const pipeline = util.promisify(require('stream').pipeline);
+const bigJson = require('big-json');
+
+(async () => {
+	// await compressDatabase();
+	// console.log(await unD());
+	const car = {
+		name: 'Lambo',
+		color: 'Matte Black'
+	};
+	const stringifyStream = bigJson.createStringifyStream({
+		body: car
+	});
+	await pipeline(stringifyStream, zlib.createGzip(), fs.createWriteStream('./assets/TESTING.json'));
+	const dec = await decompressDatabase('./assets/TESTING.json');
+	console.log(dec);
+	/* const chunks = [];
+	const decompress = zlib.createGunzip();
+	fs.createReadStream('./assets/LBF Database.json.gz').pipe(decompress).on('data', chunk => {
+		chunks.push(chunk);
+	}).on('end', () => {
+		const dec = Buffer.concat(chunks);
+		console.log(JSON.parse(dec.toString()));
+		return dec;
+	}); */
+})();
+
+function getLastModifiedDateSync(_path) {
+	return fs.statSync(_path).mtimeMs;
+}
+
+function getNestedLastModifiedDateSync(_path) {
+	let lastModified;
+	const dirs = fs.readdirSync(_path, {
+		withFileTypes: true
+	}).filter(dirent => dirent.isDirectory()).map(dirent => dirent.name);
+	for (let dir of dirs) {
+		const tempLastModified = getLastModifiedDateSync(path.join(_path, dir));
+		lastModified = lastModified < tempLastModified ? lastModified : tempLastModified;
+	}
+	return lastModified;
+}
+
+async function compressDatabaseFromFile() {
+	return pipeline(fs.createReadStream('./assets/LBF Database.json'), zlib.createGzip(), fs.createWriteStream('./assets/LBF Database.json.gz'));
+}
+
+async function compressDatabaseFromJSON(jsonDB) {
+	return pipeline(bigJson.createStringifyStream({
+		body: jsonDB
+	}), zlib.createGzip(), fs.createWriteStream('./assets/LBF Database.json.gz'));
+}
+
+async function decompressDatabase(compressedPath = './assets/LBF Database.json.gz') {
+	const chunks = [];
+	const stream = fs.createReadStream(compressedPath).pipe(zlib.createGunzip()).on('data', chunk => {
+		chunks.push(chunk);
+	});
+	return new Promise((res) => {
+		stream.on('end', () => {
+			res(JSON.parse(Buffer.concat(chunks).toString()));
+		});
+	});
+}
+
+async function writeDecompressedDatabase() {
+	return pipeline(fs.createReadStream('./assets/LBF Database.json.gz'), zlib.createGunzip(), fs.createWriteStream('./assets/LBF Database.json'));
+}
+
+module.exports = {
+	getLastModifiedDateSync: getLastModifiedDateSync,
+	getNestedLastModifiedDateSync: getNestedLastModifiedDateSync,
+	compressDatabaseFromFile: compressDatabaseFromFile,
+	compressDatabaseFromJSON: compressDatabaseFromJSON,
+	decompressDatabase: decompressDatabase,
+	writeDecompressedDatabase: writeDecompressedDatabase
+};

--- a/testing/google-scraping-testing.js
+++ b/testing/google-scraping-testing.js
@@ -6,7 +6,7 @@ const {
 
 const SCOPES = ['https://www.googleapis.com/auth/drive.readonly'];
 const TOKEN_PATH = './assets/google/token.json';
-const OAUTH = require('./assets/google/OAuth2 Config.json');
+const OAUTH = require('./assets/google/oauth2-config.json');
 
 const oauth2Client = new google.auth.OAuth2(
 	OAUTH.clientId,

--- a/testing/google-scraping-testing.js
+++ b/testing/google-scraping-testing.js
@@ -1,0 +1,186 @@
+const fs = require('fs');
+const readline = require('readline');
+const {
+	google
+} = require('googleapis');
+
+const SCOPES = ['https://www.googleapis.com/auth/drive.readonly'];
+const TOKEN_PATH = './assets/google/token.json';
+const OAUTH = require('./assets/google/OAuth2 Config.json');
+
+const oauth2Client = new google.auth.OAuth2(
+	OAUTH.clientId,
+	OAUTH.secret,
+	OAUTH.redirect
+);
+
+// getAccessToken(oauth2Client, scrape);
+
+fs.readFile('./assets/google/credentials.json', (err, content) => {
+	if (err) return console.log('Error loading client secret file:', err);
+	// Authorize a client with credentials, then call the Google Drive API.
+	// authorize(JSON.parse(content), scrapeDrive);
+	authorize(JSON.parse(content), scrapeSheet)
+});
+
+/**
+ * Create an OAuth2 client with the given credentials, and then execute the
+ * given callback function.
+ * @param {Object} credentials The authorization client credentials.
+ * @param {function} callback The callback to call with the authorized client.
+ */
+function authorize(credentials, callback) {
+	const {
+		client_secret,
+		client_id,
+		redirect_uris
+	} = credentials.installed;
+	const oAuth2Client = new google.auth.OAuth2(
+		client_id, client_secret, redirect_uris[0]);
+
+	// Check if we have previously stored a token.
+	fs.readFile(TOKEN_PATH, (err, token) => {
+		if (err) return getAccessToken(oAuth2Client, callback);
+		oAuth2Client.setCredentials(JSON.parse(token));
+		callback(oAuth2Client);
+	});
+}
+
+/**
+ * Get and store new token after prompting for user authorization, and then
+ * execute the given callback with the authorized OAuth2 client.
+ * @param {google.auth.OAuth2} oAuth2Client The OAuth2 client to get token for.
+ * @param {getEventsCallback} callback The callback for the authorized client.
+ */
+async function getAccessToken(oAuth2Client, callback) {
+	const authUrl = oAuth2Client.generateAuthUrl({
+		access_type: 'offline',
+		scope: SCOPES,
+	});
+	console.log('Authorize this app by visiting this url:', authUrl);
+	const rl = readline.createInterface({
+		input: process.stdin,
+		output: process.stdout,
+	});
+	await rl.question('Enter the code from that page here: ', (code) => {
+		rl.close();
+		oAuth2Client.getToken(code, (err, token) => {
+			if (err) return console.error('Error retrieving access token', err);
+			oAuth2Client.setCredentials(token);
+			// Store the token to disk for later program executions
+			fs.writeFile(TOKEN_PATH, JSON.stringify(token), (err) => {
+				if (err) return console.error(err);
+				console.log('Token stored to', TOKEN_PATH);
+			});
+			callback(oAuth2Client);
+		});
+	});
+}
+
+
+async function scrapeDrive(auth) {
+	const drive = google.drive({
+		version: 'v3',
+		auth: auth,
+	});
+	let parseFiles = [];
+	let files = [];
+
+	let res = await drive.files.list({
+		// q: `'1s4QGfIgFXetVA9LExwjilSdTY4ysqC36' in parents and mimeType = 'application/vnd.google-apps.folder'`,
+		q: `'1Tri2ajaUm4YksE84sqEqmMChUSCJpKU7' in parents and (name contains 'Gimpo' or name contains 'GMP') and (name contains 'Incheon' or name contains 'ICN')`
+	});
+	log(res.data);
+	/* parseFiles = res.data.files.map(folder => folder.id);
+	for (let nestedFolder of parseFiles) {
+		let nestedRes = await drive.files.list({
+			q: `'${nestedFolder}' in parents and mimeType contains 'image/'`
+		});
+		console.log(nestedRes.data);
+	} */
+}
+
+async function scrapeSheet(auth) {
+	const sheetsApi = google.sheets({
+		version: 'v4',
+		auth: auth,
+	});
+
+	const spreadsheetIds = ['1ZJw_TcUnMVDfcYo6SRssM-zCmFUiUAM2XfCLl6oj5rc', '128qKdqfKLLSWN8YBQTDRsTNPK1WEugN5cAz1hyRVTj8'];
+	for (const spreadsheetId of spreadsheetIds) {
+		let res = await sheetsApi.spreadsheets.get({
+			spreadsheetId: spreadsheetId,
+		});
+		log(`Scrapping through ${res.data.properties.title} spreadsheet...`);
+		let sheets = res.data.sheets.map(sheet => {
+			return {
+				'sheetId': sheet.properties.sheetId,
+				'title': sheet.properties.title.trim(),
+				'rows': sheet.properties.gridProperties.rowCount,
+				'columns': sheet.properties.gridProperties.columnCount,
+			}
+		});
+		// log(sheets);
+
+		const scrapped = [];
+		for (let sheet of sheets) {
+			// Everything starts at 1, Col 1 = A, Row 1 = 1
+			res = await sheetsApi.spreadsheets.values.get({
+				spreadsheetId: spreadsheetId,
+				range: `${sheet.title}!A:${toLetter(sheet.columns)}`
+			});
+			const hits = [];
+			const indexes = getIndexes(res.data.values.shift()); // #shift removes 1st element from array and returns it
+			if (indexes) {
+				for (const row of res.data.values.filter(row => row.length)) {
+					if (row[indexes.event].match(/GMP|Gimpo|Incheon|ICN/gi) != null) {
+						hits.push({
+							date: row[indexes.date].trim(),
+							event: row[indexes.event].trim(),
+							link: row[indexes.link].trim()
+						});
+					}
+				}
+				scrapped.push({
+					'name': sheet.title,
+					'data': hits
+				});
+			}
+		}
+
+		for (const idol of scrapped) {
+			log(`${idol.data.length} events to parse for ${idol.name}.`);
+		}
+	}
+}
+
+// https://stackoverflow.com/a/53678158/7835042
+function toLetter(n) {
+	n = n - 1; // Makes it so that everything starts at 1, since Google Sheets row and col start at 1
+	return (a = Math.floor(n / 26)) >= 0 ? toLetter(a - 1) + String.fromCharCode(65 + (n % 26)) : '';
+}
+
+function getIndexes(row) {
+	const indexes = {};
+	for (const cell in row) {
+		// Change to if statements and use regex in the future in case of more mistakes
+		switch (row[cell].toLowerCase().trim()) {
+			case 'date':
+				indexes.date = cell;
+				break;
+			case 'event':
+				indexes.event = cell;
+				break;
+			case 'link':
+				indexes.link = cell;
+				break;
+			default:
+				break;
+		}
+	}
+	return Object.keys(indexes).length == 3 ? indexes : undefined;
+}
+
+function log(msg) {
+	console.log(`[${new Date().toLocaleString()}] ${msg}`);
+}


### PR DESCRIPTION
- Add new dependencies and upgrade tfjs-node
 - Production code uses tfjs-node-gpu (GPU) instead of tfjs-node (CPU)
   - Requires extra setting up, if you don't want to, require tfjs-node instead
     - TODO: Allow user to declare whether or not they want to use GPU
	   - Could be difficult/dependent on user's successful installation
   - Results in building the database faster
 - Added testing programs
   - These were used to help test code before adapting them for production
   - google-scraping-testing requires 3 sensitive files to be used
   - The code in these programs could break at any point, or have
   different results than that of when pushed to live
   - You need to place these in `./assets/google/`, see code for naming